### PR TITLE
feat: ignoreErrorOnCondition으로 에러 UI 노출 여부 제어

### DIFF
--- a/comento_design_system/lib/src/components/buttons/cds_elevated_button.dart
+++ b/comento_design_system/lib/src/components/buttons/cds_elevated_button.dart
@@ -315,8 +315,7 @@ class CdsElevatedButton extends StatelessWidget {
         return CdsColors.grey100;
       }),
       overlayColor: MaterialStateProperty.resolveWith((states) {
-        if (isToggled) return CdsColors.blue200;
-        return CdsColors.grey200;
+        return CdsColors.blue100;
       }),
     );
   }

--- a/comento_design_system/lib/src/components/inputs/cds_outlined_text_area.dart
+++ b/comento_design_system/lib/src/components/inputs/cds_outlined_text_area.dart
@@ -11,6 +11,7 @@ class CdsOutlinedTextArea extends StatefulWidget {
   final FormFieldValidator<String>? validator;
   final bool autocorrect;
   final bool ignoreErrorOnEmpty;
+  final bool ignoreErrorOnCondition;
   final String? hintText;
   final int? maxLength;
   final double areaHeight;
@@ -28,6 +29,7 @@ class CdsOutlinedTextArea extends StatefulWidget {
     this.validator,
     this.hintText,
     this.ignoreErrorOnEmpty = true,
+    this.ignoreErrorOnCondition = false,
     this.maxLength,
     this.errorText,
   })  : receivedController = controller,
@@ -84,6 +86,10 @@ class _CdsOutlinedTextAreaState extends State<CdsOutlinedTextArea> {
     if (_errorText == null) {
       return FieldErrorState.none;
     }
+    if (widget.ignoreErrorOnCondition) {
+      return FieldErrorState.hideAll;
+    }
+
     if (isEmpty) {
       return widget.ignoreErrorOnEmpty
           ? FieldErrorState.hideAll
@@ -123,7 +129,8 @@ class _CdsOutlinedTextAreaState extends State<CdsOutlinedTextArea> {
         fillColor: CdsColors.white,
         filled: true,
         hintStyle: TextStyle(
-          color: _errorState == FieldErrorState.none
+          color: _errorState == FieldErrorState.none ||
+                  _errorState == FieldErrorState.hideAll
               ? CdsColors.grey300
               : CdsColors.error,
         ),

--- a/comento_design_system/lib/src/components/inputs/cds_outlined_text_field.dart
+++ b/comento_design_system/lib/src/components/inputs/cds_outlined_text_field.dart
@@ -14,6 +14,7 @@ class CdsOutlinedTextField extends StatefulWidget {
   final bool obscureText;
   final bool readOnly;
   final bool ignoreErrorOnEmpty;
+  final bool ignoreErrorOnCondition;
   final String? initialValue;
   final String? hintText;
   final String? errorText;
@@ -34,6 +35,7 @@ class CdsOutlinedTextField extends StatefulWidget {
     this.initialValue,
     this.hintText,
     this.ignoreErrorOnEmpty = true,
+    this.ignoreErrorOnCondition = false,
     this.readOnly = false,
     this.errorText,
     this.successText,
@@ -95,6 +97,11 @@ class _CdsOutlinedTextFieldState extends State<CdsOutlinedTextField> {
     if (_errorText == null) {
       return FieldErrorState.none;
     }
+
+    if (widget.ignoreErrorOnCondition) {
+      return FieldErrorState.hideAll;
+    }
+
     if (isEmpty) {
       return widget.ignoreErrorOnEmpty
           ? FieldErrorState.hideAll
@@ -144,7 +151,8 @@ class _CdsOutlinedTextFieldState extends State<CdsOutlinedTextField> {
             ),
         },
         hintStyle: TextStyle(
-          color: _errorState == FieldErrorState.none
+          color: _errorState == FieldErrorState.none ||
+                  _errorState == FieldErrorState.hideAll
               ? CdsColors.grey300
               : CdsColors.error,
         ),


### PR DESCRIPTION
onSubmit 버튼을 누르기 전까진 error UI가 뜨면안된다는 조건처럼,
추후 어떤 조건에 의해 에러 UI 노출을 달리하는 기능이 추가될 수 있기 때문에
해당 파라미터를 통해 단순 validator로만 error ui를 띄우는 것이 아닌,
특정 조건에 의해 error UI를 노출하도록 기능을 추가했습니다. 